### PR TITLE
Add converted JSON schedules for events #1134, #1143, #1146, #1151, #1154

### DIFF
--- a/DataSet Tools/raw/json/sqlsat1134.json
+++ b/DataSet Tools/raw/json/sqlsat1134.json
@@ -1,0 +1,241 @@
+{
+  "event": "SQL Saturday Croatia 2026 (#1134)",
+  "location": "Zagreb, Croatia",
+  "eventDate": "2026-06-13",
+  "sessions": [
+    {
+      "time": "12:45 am",
+      "duration": "15 min",
+      "title": "Keynote",
+      "type": "keynote"
+    },
+    {
+      "time": "1:00 am",
+      "duration": "60 min",
+      "title": "CTE Myths—Busted!",
+      "speaker": "Uwe Ricken",
+      "level": "Advanced",
+      "category": "SQL Development"
+    },
+    {
+      "time": "1:00 am",
+      "duration": "60 min",
+      "title": "Vibing with SQL: AI in the Developer’s Seat",
+      "speaker": "Marco Dal Pino",
+      "level": "Introductory and overview",
+      "category": "SQL Development"
+    },
+    {
+      "time": "1:00 am",
+      "duration": "60 min",
+      "title": "Real-Time or Real Enough? What 'Fast' Actually Means in Fabric",
+      "speaker": "Karin Szilágyi",
+      "level": "Intermediate",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "1:00 am",
+      "duration": "60 min",
+      "title": "Apache Spark for SQL Data Warehouse Developers",
+      "speaker": "Olivier Van Steenlandt",
+      "level": "Intermediate",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "2:00 am",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "2:15 am",
+      "duration": "60 min",
+      "title": "Window to Success: Mastering SQL Server Window Functions",
+      "speaker": "Daniel Hutmacher",
+      "level": "Intermediate",
+      "category": "SQL Development"
+    },
+    {
+      "time": "2:15 am",
+      "duration": "60 min",
+      "title": "A heap of trouble: the hidden costs of heaps in SQL Server",
+      "speaker": "Vlad Drumea",
+      "level": "Intermediate",
+      "category": "SQL Development"
+    },
+    {
+      "time": "2:15 am",
+      "duration": "60 min",
+      "title": "A Persona-Driven Adoption Framework: How to Design BI Reports for Decisions",
+      "speaker": "Zita Pelok",
+      "level": "Intermediate",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "2:15 am",
+      "duration": "60 min",
+      "title": "Model Context Protocol (MCP) for Azure SQL- How AI Agents Can Create, Maintain & Query Your Database",
+      "speaker": "Mario Pilija",
+      "level": "Intermediate",
+      "category": "Other"
+    },
+    {
+      "time": "3:15 am",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "3:30 am",
+      "duration": "60 min",
+      "title": "Fuzzy Matching",
+      "speaker": "Dejan Sarka",
+      "level": "Expert",
+      "category": "SQL Development"
+    },
+    {
+      "time": "3:30 am",
+      "duration": "60 min",
+      "title": "How to Build Workflow-Driven Database Provisioning in Azure DevOps",
+      "speaker": "Tonie Huizer",
+      "level": "Intermediate",
+      "category": "SQL Development"
+    },
+    {
+      "time": "3:30 am",
+      "duration": "60 min",
+      "title": "Lost in Fabric? Here’s Your Map!",
+      "speaker": "Augustin Dokoza Bukvic",
+      "level": "Introductory and overview",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "3:30 am",
+      "duration": "60 min",
+      "title": "My data is GOOD?",
+      "speaker": "Catalin Gheorghiu",
+      "level": "Intermediate",
+      "category": "Other"
+    },
+    {
+      "time": "4:30 am",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "4:45 am",
+      "duration": "60 min",
+      "title": "Optimizacija procedura sa opcionim parametrima u SQL Serveru",
+      "speaker": "Milos Radivojevic",
+      "level": "Intermediate",
+      "category": "SQL Development"
+    },
+    {
+      "time": "4:45 am",
+      "duration": "60 min",
+      "title": "SQL Server 2025 Vector Data Type and AI Models",
+      "speaker": "Mladen Prajdic",
+      "level": "Intermediate",
+      "category": "SQL Development"
+    },
+    {
+      "time": "4:45 am",
+      "duration": "60 min",
+      "title": "Advanced DAX for Analytical Insights in Power BI with Visualization Best Practices",
+      "speaker": "Anastazija Crnkovic",
+      "level": "Advanced",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "4:45 am",
+      "duration": "60 min",
+      "title": "Paswordless Azure SQL Connections",
+      "speaker": "Daniel Gregurić",
+      "level": "Intermediate",
+      "category": "Other"
+    },
+    {
+      "time": "5:45 am",
+      "duration": "45 min",
+      "title": "Lunch break",
+      "type": "lunch"
+    },
+    {
+      "time": "6:30 am",
+      "duration": "60 min",
+      "title": "The Latest Performance Improvements in Azure SQL Database, Managed Instance, and SQL Server 2025",
+      "speaker": "Ola Hallengren",
+      "level": "Intermediate",
+      "category": "SQL Administration"
+    },
+    {
+      "time": "6:30 am",
+      "duration": "60 min",
+      "title": "Indexing Strategies for Vector Search in SQL Server",
+      "speaker": "Mihail Mateev",
+      "level": "Advanced",
+      "category": "SQL Development"
+    },
+    {
+      "time": "6:30 am",
+      "duration": "60 min",
+      "title": "Transition from Data Analyst to Data Engineer: Upgrading Skills from DataFlows Gen2 to Notebooks",
+      "speaker": "Nikola Ilic",
+      "level": "Introductory and overview",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "6:30 am",
+      "duration": "60 min",
+      "title": "Complex access control with Row-Level Security",
+      "speaker": "Mathias Halkjaer",
+      "level": "Advanced",
+      "category": "Other"
+    },
+    {
+      "time": "7:30 am",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "7:45 am",
+      "duration": "60 min",
+      "title": "For a Few Rows More: Mastering Row Goals in SQL Server",
+      "speaker": "Erik Darling",
+      "level": "Intermediate",
+      "category": "SQL Development"
+    },
+    {
+      "time": "7:45 am",
+      "duration": "60 min",
+      "title": "Building an end-to-end data solution with Microsoft Fabric",
+      "speaker": "Christian Gregorec",
+      "level": "Intermediate",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "7:45 am",
+      "duration": "60 min",
+      "title": "DAX Demystified: 5 Key Lessons Every Beginner Needs to Learn Early",
+      "speaker": "Markus Ehrenmueller-Jensen",
+      "level": "Intermediate",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "7:45 am",
+      "duration": "60 min",
+      "title": "Ups and downs on PowerBI and Real-Time intelligence",
+      "speaker": "Brian Bønk",
+      "level": "Introductory and overview",
+      "category": "BI & Analytics"
+    },
+    {
+      "time": "8:45 am",
+      "duration": "15 min",
+      "title": "Conference closing and prize draw - must be present to win",
+      "type": "closing"
+    }
+  ]
+}

--- a/DataSet Tools/raw/json/sqlsat1143.json
+++ b/DataSet Tools/raw/json/sqlsat1143.json
@@ -1,0 +1,194 @@
+{
+  "event": "Raleigh Day of Data 2026 (#1143)",
+  "location": "Raleigh, NC",
+  "eventDate": "2026-05-23",
+  "sessions": [
+    {
+      "time": "8:00 am",
+      "duration": "30 min",
+      "title": "Registration",
+      "room": "1002 (Auditorium)",
+      "type": "registration"
+    },
+    {
+      "time": "8:30 am",
+      "duration": "60 min",
+      "title": "Designing for Failure: Engineering AI Systems That Degrade Gracefully",
+      "speaker": "Angel Ceballos"
+    },
+    {
+      "time": "8:30 am",
+      "duration": "60 min",
+      "title": "Data Data Everywhere: A Look At Data Hoarding",
+      "speaker": "Peter Shore"
+    },
+    {
+      "time": "8:30 am",
+      "duration": "60 min",
+      "title": "Fast Backup and Restore without Touching Your Storage",
+      "speaker": "Mark Wilkinson"
+    },
+    {
+      "time": "8:30 am",
+      "duration": "60 min",
+      "title": "From DBA to AI Agent Wrangler: Bringing Safe, Compliant AI Agents to SQL Server",
+      "speaker": "Carlos Chacon"
+    },
+    {
+      "time": "9:30 am",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "9:45 am",
+      "duration": "60 min",
+      "title": "Intro to PowerShell with dbatools for the DBA",
+      "speaker": "Tony Wilhelm"
+    },
+    {
+      "time": "9:45 am",
+      "duration": "60 min",
+      "title": "Demystifying vector search in SQL 2025",
+      "speaker": "Mala Mahadevan"
+    },
+    {
+      "time": "9:45 am",
+      "duration": "60 min",
+      "title": "BI versus Relational Design",
+      "speaker": "Louis Davidson"
+    },
+    {
+      "time": "9:45 am",
+      "duration": "60 min",
+      "title": "Introduction to Large Scale and Real-time Analytics on Microsoft's cloud.",
+      "speaker": "Elaine Cahill"
+    },
+    {
+      "time": "10:45 am",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "11:00 am",
+      "duration": "60 min",
+      "title": "One Bite at a Time: Deleting Millions of Rows from Production Systems",
+      "speaker": "Jared Poche"
+    },
+    {
+      "time": "11:00 am",
+      "duration": "60 min",
+      "title": "The Self-Documenting Fabric: Automating Metadata with OpenAI and Microsoft Fabric",
+      "speaker": "Alan Ferrandiz"
+    },
+    {
+      "time": "11:00 am",
+      "duration": "60 min",
+      "title": "Accidental friends: how a DBA and an SRE worked together to optimize the system.",
+      "speaker": "Kayla Boor"
+    },
+    {
+      "time": "11:00 am",
+      "duration": "60 min",
+      "title": "Tech Writing for Techies: A Primer",
+      "speaker": "Ray Kim"
+    },
+    {
+      "time": "12:00 pm",
+      "duration": "60 min",
+      "title": "Lunch",
+      "type": "lunch"
+    },
+    {
+      "time": "1:00 pm",
+      "duration": "60 min",
+      "title": "The Fabric Fast Track Workbook: Deploy Enterprise Analytics in 90 Days",
+      "speaker": "Jonathan Stewart"
+    },
+    {
+      "time": "1:00 pm",
+      "duration": "60 min",
+      "title": "Immutable SQL Server - Pets vs Cows",
+      "speaker": "Michael Wall"
+    },
+    {
+      "time": "1:00 pm",
+      "duration": "60 min",
+      "title": "Microsoft SQL and AMD in the Era of AI",
+      "speaker": "John Kerski"
+    },
+    {
+      "time": "1:00 pm",
+      "duration": "60 min",
+      "title": "Engineering Cost-Efficient Cloud Architectures for Financial Data Workloads",
+      "speaker": "Naga Chand Putta"
+    },
+    {
+      "time": "2:00 pm",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "2:15 pm",
+      "duration": "60 min",
+      "title": "SQL Techniques You Should Know",
+      "speaker": "Louis Davidson"
+    },
+    {
+      "time": "2:15 pm",
+      "duration": "60 min",
+      "title": "The Architecture of Trust: Building AI Projects That Deliver ROI",
+      "speaker": "Leslie Welch"
+    },
+    {
+      "time": "2:15 pm",
+      "duration": "60 min",
+      "title": "Regular Expressions: Beyond the Basics (Slightly)",
+      "speaker": "Solomon Rutzky"
+    },
+    {
+      "time": "2:15 pm",
+      "duration": "60 min",
+      "title": "The AI-Enhanced Database Engineer: Scaling with Cursor and Claude for Massive SQL Server Fleets",
+      "speaker": "Jeff Mlakar"
+    },
+    {
+      "time": "3:15 pm",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "3:30 pm",
+      "duration": "60 min",
+      "title": "Leveraging Large Language Models with Power BI",
+      "speaker": "John Kerski"
+    },
+    {
+      "time": "3:30 pm",
+      "duration": "60 min",
+      "title": "The Hero’s Journey: Mastering Your New DBA Role",
+      "speaker": "Tracy Boggiano"
+    },
+    {
+      "time": "3:30 pm",
+      "duration": "60 min",
+      "title": "Modern Integration, Classic Toolset: A Practical Look at SSIS",
+      "speaker": "Courtney Woolum"
+    },
+    {
+      "time": "3:30 pm",
+      "duration": "60 min",
+      "title": "When Small Language Models Beat Large Ones in Production",
+      "speaker": "Nihal Kaul"
+    },
+    {
+      "time": "4:30 pm",
+      "duration": "30 min",
+      "title": "Closing Remarks and Raffles",
+      "type": "closing"
+    }
+  ]
+}

--- a/DataSet Tools/raw/json/sqlsat1146.json
+++ b/DataSet Tools/raw/json/sqlsat1146.json
@@ -1,0 +1,80 @@
+{
+  "event": "SQL Saturday Wellington 2026 (#1146)",
+  "location": "Wellington, New Zealand",
+  "eventDate": "2026-05-30",
+  "sessions": [
+    {
+      "time": "8:30 am",
+      "duration": "30 min",
+      "title": "Registration",
+      "room": "Room 1",
+      "type": "registration"
+    },
+    {
+      "time": "9:00 am",
+      "duration": "15 min",
+      "title": "Welcome",
+      "type": "opening"
+    },
+    {
+      "time": "9:15 am",
+      "duration": "60 min",
+      "title": "Microsoft SQL and AMD in the Era of AI",
+      "speaker": "Anupama Natarajan"
+    },
+    {
+      "time": "10:15 am",
+      "duration": "30 min",
+      "title": "Morning Tea",
+      "type": "break"
+    },
+    {
+      "time": "10:45 am",
+      "duration": "60 min",
+      "title": "Query Store for the \"Accidental Performance Tuner\"",
+      "speaker": "Rob Douglas"
+    },
+    {
+      "time": "11:45 am",
+      "duration": "15 min",
+      "title": "Break",
+      "type": "break"
+    },
+    {
+      "time": "12:00 pm",
+      "duration": "60 min",
+      "title": "Agentic Data Engineering: Building a Modern Data Platform with AI Agents",
+      "speaker": "Ram Katepally"
+    },
+    {
+      "time": "1:00 pm",
+      "duration": "60 min",
+      "title": "Lunch",
+      "type": "lunch"
+    },
+    {
+      "time": "2:00 pm",
+      "duration": "60 min",
+      "title": "Securing AI in the Enterprise: From Prompt to Production",
+      "speaker": "Zahid Yaqub"
+    },
+    {
+      "time": "3:00 pm",
+      "duration": "15 min",
+      "title": "Afternoon Tea",
+      "type": "break"
+    },
+    {
+      "time": "3:15 pm",
+      "duration": "60 min",
+      "title": "The Rise of Agentic BI: Fabric & Power BI MCP Live",
+      "speaker": "Anupama Natarajan"
+    },
+    {
+      "time": "4:15 pm",
+      "duration": "15 min",
+      "title": "Raffle Prizes & Wrap up",
+      "type": "closing"
+    }
+  ]
+}

--- a/DataSet Tools/raw/json/sqlsat1151.json
+++ b/DataSet Tools/raw/json/sqlsat1151.json
@@ -1,0 +1,82 @@
+{
+  "event": "SQL Saturday CXS 2026 (#1151)",
+  "location": "Caxias do Sul, RS, Brazil",
+  "eventDate": "2026-06-27",
+  "sessions": [
+    {
+      "time": "7:30 am",
+      "duration": "45 min",
+      "title": "Credenciamento",
+      "type": "registration"
+    },
+    {
+      "time": "8:15 am",
+      "duration": "35 min",
+      "title": "Abertura / Keynote: Microsoft SQL and AMD in the Era of AI",
+      "speaker": "Rodrigo Crespi",
+      "type": "keynote"
+    },
+    {
+      "time": "9:00 am",
+      "duration": "50 min",
+      "title": "Pwned! Tomada e controle de Banco de Dados por atacantes",
+      "speaker": "Mateus Buogo",
+      "room": "Auditório"
+    },
+    {
+      "time": "9:00 am",
+      "duration": "50 min",
+      "title": "Seus dados não podem ir para a nuvem, e agora? O Azure Local pode ser a sua resposta",
+      "speaker": "Ismael Casagrande",
+      "room": "Anfiteatro"
+    },
+    {
+      "time": "10:00 am",
+      "duration": "50 min",
+      "title": "Azure SQL Server e o Imposto do Poliglota",
+      "speaker": "Glauber Cini",
+      "room": "Auditório"
+    },
+    {
+      "time": "10:00 am",
+      "duration": "50 min",
+      "title": "De Software Legado à Escala SaaS: os desafios reais de transformar uma software house tradicional",
+      "speaker": "Braian Erlindo Horn de Borba",
+      "room": "Anfiteatro"
+    },
+    {
+      "time": "11:00 am",
+      "duration": "50 min",
+      "title": "Conversando com o SQL Server usando IA, MCP Servers e Linguagem Natural",
+      "speaker": "Diego Matos",
+      "room": "Auditório"
+    },
+    {
+      "time": "11:00 am",
+      "duration": "50 min",
+      "title": "Generative AI Platform: Create, Reuse, and Accelerate",
+      "speaker": "Marcus Bittencourt",
+      "room": "Anfiteatro"
+    },
+    {
+      "time": "12:00 pm",
+      "duration": "50 min",
+      "title": "Consulta de dados externos com Microsoft Foundry e consultas semânticas no Azure",
+      "speaker": "Luciano Gambato",
+      "room": "Auditório"
+    },
+    {
+      "time": "12:00 pm",
+      "duration": "50 min",
+      "title": "Pare de Automatizar Errado! Os bastidores da automação que ninguém te conta",
+      "speaker": "Rafael Felipe, Pedro Filippi",
+      "room": "Anfiteatro"
+    },
+    {
+      "time": "1:00 pm",
+      "duration": "30 min",
+      "title": "Encerramento",
+      "type": "closing"
+    }
+  ]
+}

--- a/DataSet Tools/raw/json/sqlsat1154.json
+++ b/DataSet Tools/raw/json/sqlsat1154.json
@@ -1,0 +1,155 @@
+{
+  "event": "SQL Saturday Austin 2026 (#1154)",
+  "location": "Austin, TX",
+  "eventDate": "2026-06-27",
+  "sessions": [
+    {
+      "time": "7:45 am",
+      "duration": "15 min",
+      "title": "Registration",
+      "room": "Cedar",
+      "type": "registration"
+    },
+    {
+      "time": "8:00 am",
+      "duration": "60 min",
+      "title": "Move to Fabric Data Factory",
+      "speaker": "Ryan Adams"
+    },
+    {
+      "time": "8:00 am",
+      "duration": "60 min",
+      "title": "Power BI Meets AI Agents: Getting Started with the Model Context Protocol (MCP)",
+      "speaker": "Russel Loski"
+    },
+    {
+      "time": "8:00 am",
+      "duration": "60 min",
+      "title": "Getting Started: What is a Database and How Do I Use One?",
+      "speaker": "Conor Cunningham"
+    },
+    {
+      "time": "9:10 am",
+      "duration": "60 min",
+      "title": "Next-Level BI Development: AI-Driven Semantic Models in Power BI",
+      "speaker": "Kevin Arnold"
+    },
+    {
+      "time": "9:10 am",
+      "duration": "60 min",
+      "title": "Accelerating Data Stack Development with MCP Servers",
+      "speaker": "Ginger Grant"
+    },
+    {
+      "time": "9:10 am",
+      "duration": "60 min",
+      "title": "Querying Your Data: A Beginner's 60-Minute SQL Bootcamp",
+      "speaker": "John Sterrett"
+    },
+    {
+      "time": "9:10 am",
+      "duration": "60 min",
+      "title": "Röck Yoür Cäreer: Time-Tested Wisdom from a 30-Year Software Engineering Veteran",
+      "speaker": "David McCarter"
+    },
+    {
+      "time": "10:20 am",
+      "duration": "60 min",
+      "title": "PostGres: The Elephant in the Room You Can't Ignore",
+      "speaker": "Paresh Motiwala"
+    },
+    {
+      "time": "10:20 am",
+      "duration": "60 min",
+      "title": "Data Virtualization in SQL Server",
+      "speaker": "Kevin Feasel"
+    },
+    {
+      "time": "10:20 am",
+      "duration": "60 min",
+      "title": "A Gentle (Re-) Introduction to Dimensional Modeling",
+      "speaker": "Chris Hyde"
+    },
+    {
+      "time": "10:20 am",
+      "duration": "60 min",
+      "title": "Unleash Your Inner Rockstar: The 5 Steps to Dynamic Public Speaking!",
+      "speaker": "David McCarter"
+    },
+    {
+      "time": "11:25 am",
+      "duration": "70 min",
+      "title": "Lunch",
+      "room": "Cedar",
+      "type": "lunch"
+    },
+    {
+      "time": "11:35 am",
+      "duration": "60 min",
+      "title": "Microsoft SQL and AMD in the Era of AI",
+      "speaker": "Bob Ward"
+    },
+    {
+      "time": "12:45 pm",
+      "duration": "60 min",
+      "title": "PostgreSQL High Availability for the Career SQL Server DBA",
+      "speaker": "Rick Lowe"
+    },
+    {
+      "time": "12:45 pm",
+      "duration": "60 min",
+      "title": "Hardware-Accelerated Analytics Queries Explained",
+      "speaker": "Conor Cunningham"
+    },
+    {
+      "time": "12:45 pm",
+      "duration": "60 min",
+      "title": "Your Next Step Beyond SQL: Certifications, Community, and Career Growth",
+      "speaker": "Sammy Cheung"
+    },
+    {
+      "time": "1:55 pm",
+      "duration": "60 min",
+      "title": "Azure SQL Hyperscale: The Cloud Database for the era of AI",
+      "speaker": "Bob Ward"
+    },
+    {
+      "time": "1:55 pm",
+      "duration": "60 min",
+      "title": "Copy Job: Data Movement Made Simple",
+      "speaker": "Ryan Adams"
+    },
+    {
+      "time": "3:05 pm",
+      "duration": "60 min",
+      "title": "SQL in the Fabric Era: Translate existing skills into the modern data platform",
+      "speaker": "Kevin Pereira"
+    },
+    {
+      "time": "3:05 pm",
+      "duration": "60 min",
+      "title": "Introduction to Microsoft Fabric Variable Library: Simplifying CI/CD Automation",
+      "speaker": "Kevin Arnold"
+    },
+    {
+      "time": "3:05 pm",
+      "duration": "60 min",
+      "title": "Implementing Medallion Architecture in Fabric",
+      "speaker": "Ginger Grant"
+    },
+    {
+      "time": "4:05 pm",
+      "duration": "15 min",
+      "title": "Raffles",
+      "room": "Cedar",
+      "type": "closing"
+    },
+    {
+      "time": "4:35 pm",
+      "duration": "60 min",
+      "title": "Happy Hour @ The Boat",
+      "room": "Cedar",
+      "type": "social"
+    }
+  ]
+}


### PR DESCRIPTION
Convert raw text/HTML schedule exports for SQL Saturday Croatia, Raleigh Day of Data, Wellington, CXS, and Austin 2026 into the standard event JSON schema (event, location, eventDate, sessions).